### PR TITLE
Check 2nd lambda for device usage data

### DIFF
--- a/second-lambda-device-usage.md
+++ b/second-lambda-device-usage.md
@@ -1,0 +1,27 @@
+### 2nd Lambda — Do we get device usage data here too, or only through MUBU?
+
+**Short answer:** Yes — the 2nd Lambda ingests device usage data from multiple sources, not only MUBU.
+
+- **Premier/Telegence unbilled usage**: Reads latest usage files and loads them into `TelegenceAllUsageStaging`.
+- **MUBU (voice and data)**: Downloads MUBU files and loads them into `TelegenceDeviceUsageMubuStaging`, then runs follow-up sync steps.
+- **Final usage (billing-cycle close)**: When configured, loads final usage into `TelegenceDeviceFinalUsageStaging`.
+
+#### Where this happens (key spots)
+- File: `AltaworxTelegenceAWSGetDeviceUsage.cs`
+  - `ProcessDailyUsage(...)` orchestrates all three flows.
+  - Premier unbilled usage → `SqlBulkCopy(..., "TelegenceAllUsageStaging")`
+  - MUBU usage → `SqlBulkCopy(..., "TelegenceDeviceUsageMubuStaging", ...)`
+  - Final usage → `SqlBulkCopy(..., "TelegenceDeviceFinalUsageStaging")`
+
+```csharp
+// Premier unbilled usage
+SqlBulkCopy(context, context.CentralDbConnectionString, usage, "TelegenceAllUsageStaging");
+
+// MUBU usage
+SqlBulkCopy(context, context.CentralDbConnectionString, mubuUsage, "TelegenceDeviceUsageMubuStaging", MubuReportReader.GetRecordColumnMapping());
+
+// Final usage
+SqlBulkCopy(context, context.CentralDbConnectionString, finalUsage, "TelegenceDeviceFinalUsageStaging");
+```
+
+**Conclusion:** The 2nd Lambda collects device usage data from both Premier/Telegence feeds and MUBU (and optionally final usage), so it is not limited to MUBU.


### PR DESCRIPTION
This pull request contains changes generated by Cursor background composer.

<a href="https://cursor.com/background-agent?bcId=bc-41874f97-0c10-4e5b-b455-c0f7b7e049ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-41874f97-0c10-4e5b-b455-c0f7b7e049ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

